### PR TITLE
scanHelper.py: ignore any error when trying to recognise device type

### DIFF
--- a/lib/scanHelper.py
+++ b/lib/scanHelper.py
@@ -86,7 +86,7 @@ for host in nm.all_hosts():
                 row['type'] = 'gateway'
             else:
                 row['type'] = 'phone'
-        except urllib2.HTTPError, socket.timeout:
+        except:
             row['type'] = 'phone'
     if row['type'] == 'phone':
         phonesout.append(row)


### PR DESCRIPTION
not only urlopen and timeout, but any kind of error. Useful because device can fail in a lot of unexpected ways