### PR TITLE
Patton analog: add mute-dialing to prevent incorrect ringing from the provider

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4112fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4112fxo.txt
@@ -109,6 +109,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -117,6 +118,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
 context cs switch
   no shutdown

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxo.txt
@@ -138,6 +138,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -146,6 +147,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-02
     route call dest-table from_if_fxo-02
@@ -154,6 +156,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-03
     route call dest-table from_if_fxo-03
@@ -162,6 +165,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
 context cs switch
   no shutdown

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxs_fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxs_fxo.txt
@@ -122,6 +122,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -130,6 +131,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxs fxs-00
     route call dest-table TAB-OUT

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4116fxs4_fxo2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4116fxs4_fxo2.txt
@@ -124,6 +124,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -132,6 +133,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxs fxs-00
     route call dest-table TAB-OUT

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4118fxs_fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4118fxs_fxo.txt
@@ -152,6 +152,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -160,6 +161,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-02
     route call dest-table from_if_fxo-02
@@ -168,6 +170,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-03
     route call dest-table from_if_fxo-03
@@ -176,6 +179,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxs fxs-00
     route call dest-table TAB-OUT

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs2_fxo2_isdn2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs2_fxo2_isdn2.txt
@@ -170,6 +170,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -178,6 +179,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxs fxs-00
     route call dest-table TAB-OUT

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_fxo4_isdn4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_fxo4_isdn4.txt
@@ -233,6 +233,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-01
     route call dest-table from_if_fxo-01
@@ -241,6 +242,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-02
     route call dest-table from_if_fxo-02
@@ -249,6 +251,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxo fxo-03
     route call dest-table from_if_fxo-03
@@ -257,6 +260,7 @@ context cs switch
     disconnect-signal battery-reversal
     ring-number on-caller-id
     dial-after timeout 1
+    mute-dialing
 
   interface fxs fxs-00
     route call dest-table TAB-OUT


### PR DESCRIPTION
Without the parameter "mute-dialing" on analog lines, the provider may send misleading ringing waiting for the line.