### PR TITLE
qmanager permission, fix permission removal

### DIFF
--- a/root/var/www/html/freepbx/rest/modules/cti.php
+++ b/root/var/www/html/freepbx/rest/modules/cti.php
@@ -28,7 +28,7 @@ include_once('lib/libCTI.php');
 Return: [{id:1, name: admin, macro_permissions [ oppanel: {value: true, permissions [ {name: "foo", description: "descrizione...", value: false},{..} ]}
 */
 $app->get('/cti/profiles', function (Request $request, Response $response, $args) {
-    $results = getCTIPermissionProfiles();
+    $results = getCTIPermissionProfiles(false,false,true);
     if (!$results) {
         return $response->withStatus(500);
     }
@@ -43,7 +43,7 @@ $app->get('/cti/profiles/{id}', function (Request $request, Response $response, 
     try {
         $route = $request->getAttribute('route');
         $id = $route->getArgument('id');
-        $results = getCTIPermissionProfiles($id);
+        $results = getCTIPermissionProfiles($id,false,true);
         if (!$results) {
             return $response->withStatus(500);
         }


### PR DESCRIPTION
- don't return queues not already saved (id null) when writing config file
- use qmanager_[EXTEN] instead of qmanager_[NAME]_[EXTEN] as permission name
- allow to delete permission with null id
https://github.com/nethesis/dev/issues/5416