### PR TITLE
Remove user from CTI groups if is main extension is deleted

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/libExtensions.php
+++ b/root/var/www/html/freepbx/rest/lib/libExtensions.php
@@ -407,21 +407,28 @@ function createMainExtensionForUser($username,$mainextension,$outboundcid='') {
             $fpbx->Core->delUser($extension);
             $fpbx->Core->delDevice($extension);
 
-            // set values to NULL for physical devices
-            $sql = 'UPDATE rest_devices_phones'.
-              ' SET user_id = NULL'.
-              ', extension = NULL'.
-              ', secret = NULL'.
-              ' WHERE user_id = ? AND mac IS NOT NULL';
-            $stmt = $dbh->prepare($sql);
-            $stmt->execute(array($uid));
-
-            // remove user's webrtc phone and custom devices
-            $sql = 'DELETE FROM rest_devices_phones'.
-              ' WHERE user_id = ? AND mac IS NULL';
-            $stmt = $dbh->prepare($sql);
-            $stmt->execute(array($uid));
         }
+        // set values to NULL for physical devices
+        $sql = 'UPDATE rest_devices_phones'.
+          ' SET user_id = NULL'.
+          ', extension = NULL'.
+          ', secret = NULL'.
+          ' WHERE user_id = ? AND mac IS NOT NULL';
+        $stmt = $dbh->prepare($sql);
+        $stmt->execute(array($uid));
+
+        // remove user's webrtc phone and custom devices
+        $sql = 'DELETE FROM rest_devices_phones'.
+          ' WHERE user_id = ? AND mac IS NULL';
+        $stmt = $dbh->prepare($sql);
+        $stmt->execute(array($uid));
+
+        // remove user from CTI groups
+        $sql = 'DELETE FROM rest_cti_users_groups'.
+          ' WHERE user_id = ?';
+        $stmt = $dbh->prepare($sql);
+        $stmt->execute(array($uid));
+
         if (checkUsermanIsUnlocked()) {
             $fpbx->Userman->updateUser($uid, $username, $username);
         }


### PR DESCRIPTION
also move "set values to NULL for physical devices" and "remove user's webrtc phone and custom devices" out of the devices for cicle, since those two queries uses user id that doesn't change in the cicle