### PR TITLE
Fix trunk creation for updated version of FreePBX core module

### DIFF
--- a/root/var/www/html/freepbx/rest/modules/devices.php
+++ b/root/var/www/html/freepbx/rest/modules/devices.php
@@ -425,9 +425,10 @@ $app->post('/devices/gateways', function (Request $request, Response $response, 
                     $defaults['transport'] = $srvip.'-udp';
                     $defaults['trunk_name'] = $trunkName;
 
-                    // set $_REQUEST params for pjsip
+                    // set $_REQUEST and $_POST params for pjsip
                     foreach ($defaults as $k => $v) {
                         $_REQUEST[$k] = $v;
+                        $_POST[$k] = $v;
                     }
 
                     $trunkId = core_trunks_add(


### PR DESCRIPTION
Pass trunk creation options in both $_REQUEST and $_POST
Old version of core uses $_REQUEST for trunk additional parameters, newer version $_POST
https://github.com/nethesis/dev/issues/5426