### PR TITLE
Don't use broken core function for trunk name

### DIFF
--- a/root/var/www/html/freepbx/rest/modules/routes.php
+++ b/root/var/www/html/freepbx/rest/modules/routes.php
@@ -122,8 +122,9 @@ $app->get('/outboundroutes/count', function (Request $request, Response $respons
        foreach($allRoutes as $route) {
            $route_trunks = core_routing_getroutetrunksbyid($route['route_id']);
            $route['trunks'] = [];
-           foreach($route_trunks as $trunk) {
-               $route['trunks'][] = array("trunkid" => $trunk, "name" => core_trunks_getTrunkTrunkName($trunk));
+           foreach($route_trunks as $trunkID) {
+               $trunk = core_trunks_getDetails($trunkID);
+               $route['trunks'][] = array("trunkid" => $trunkID, "name" => $trunk['name']);
            }
            $routes[] = $route;
        }


### PR DESCRIPTION
also a [fix](https://github.com/FreePBX/core/pull/30) has been suggested to FreePBX, but since seems that none is using this function, is better we also start using a more common one
https://github.com/nethesis/dev/issues/5475

