### PR TITLE
Fix Patton FXS configuration:

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4112fxs.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4112fxs.txt
@@ -113,7 +113,6 @@ location-service LOC_SERV_TRAIN5
   domain 1 ASTERISKIP
 
   identity FXSEXTENSION0
-    phone-context from-internal
 
     authentication outbound
       authenticate 1 authentication-service AUTH_TRAIN username FXSEXTENSION0


### PR DESCRIPTION
- delete from-internal context in authentication configuration, it denies making an outgoing call on the first fxs port