### PR TITLE
cti helper: restart also nethvoice-report-api

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/ctiReloadHelper.sh
+++ b/root/var/www/html/freepbx/rest/lib/ctiReloadHelper.sh
@@ -4,3 +4,4 @@ while (ps aux | grep -q [r]etrieve_conf); do
 done
 sleep 2
 /usr/bin/sudo /usr/bin/systemctl reload nethcti-server
+[ -d /opt/nethvoice-report/api/ ] && /usr/bin/sudo /usr/bin/systemctl restart nethvoice-report-api

--- a/root/var/www/html/freepbx/rest/lib/ctiReloadHelper.sh
+++ b/root/var/www/html/freepbx/rest/lib/ctiReloadHelper.sh
@@ -4,4 +4,4 @@ while (ps aux | grep -q [r]etrieve_conf); do
 done
 sleep 2
 /usr/bin/sudo /usr/bin/systemctl reload nethcti-server
-[ -d /opt/nethvoice-report/api/ ] && /usr/bin/sudo /usr/bin/systemctl restart nethvoice-report-api
+[[ -d /opt/nethvoice-report/api/ ]] && /usr/bin/sudo /usr/bin/systemctl restart nethvoice-report-api


### PR DESCRIPTION
This is a less than optimal solution but it's quite clean.
The report API service is not restarted if not installed.

See also nethesis/nethserver-nethvoice#139

Nethesis/dev#5865