### PR TITLE
Launch retrieve_conf even if extension is empty

### DIFF
--- a/root/var/www/html/freepbx/rest/modules/mainextensions.php
+++ b/root/var/www/html/freepbx/rest/modules/mainextensions.php
@@ -55,11 +55,11 @@ $app->post('/mainextensions', function (Request $request, Response $response, $a
         return $response->withJson(array("status"=>'ERROR: directory is locked'), 500);
     }
 
-    if ($ret !== true) {
-        return $response->withJson($ret[0],$ret[1]);
-    }
-
     system('/var/www/html/freepbx/rest/lib/retrieveHelper.sh > /dev/null &');
-    return $response->withStatus(201);
+
+    if ($ret == true) {
+        return $response->withStatus(201);
+    }
+    return $response->withJson($ret[0],$ret[1]);
 });
 


### PR DESCRIPTION
When user extension is cleared, retrieve_conf should be launched, to
ensure that it is possible to create an extension with same number

https://github.com/nethesis/dev/issues/5906