### PR TITLE
cti: expand config before restart

### DIFF
--- a/root/etc/sudoers.d/81_nethvoice_wizard
+++ b/root/etc/sudoers.d/81_nethvoice_wizard
@@ -22,4 +22,5 @@
     /sbin/e-smith/config setprop asterisk AllowExternalSIPS enabled, \
     /sbin/e-smith/config setprop asterisk AllowExternalSIPS disabled, \
     /usr/bin/cat /var/lib/nethserver/secrets/LDAPPhonebookPasswd, \
+    /sbin/e-smith/expand-template /etc/nethcti/nethcti.json \
     /usr/bin/systemctl restart asterisk

--- a/root/var/www/html/freepbx/rest/lib/ctiReloadHelper.sh
+++ b/root/var/www/html/freepbx/rest/lib/ctiReloadHelper.sh
@@ -3,5 +3,7 @@ while (ps aux | grep -q [r]etrieve_conf); do
     sleep 1
 done
 sleep 2
+# make sure flexisip configuration is present before reload
+/sbin/e-smith/expand-template /etc/nethcti/nethcti.json
 /usr/bin/sudo /usr/bin/systemctl reload nethcti-server
 [[ -d /opt/nethvoice-report/api/ ]] && /usr/bin/sudo /usr/bin/systemctl restart nethvoice-report-api


### PR DESCRIPTION
If the nethcti-server package is installed before nethvoice,
the nethcti.json file will not contain flexisip port.
As consequence, applications configured using the QR code from
the CTI will not recieve proxy configuration.