### PR TITLE
Change Trinity config for new firmware > 3.17.1 

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_ISDN_1.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_ISDN_1.txt
@@ -111,7 +111,6 @@ location-service SER_LOC_00
       authenticate 1 authentication-service AUTH_SRV username TRUNKNUMBER1
 
 context sip-gateway ASTERISK_00
-  bind location-service SER_LOC_00
 
   interface IF_GW_SIP_TRAIN_00
     transport-protocol udp+tcp 5060

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_ISDN_2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_ISDN_2.txt
@@ -141,7 +141,6 @@ location-service SER_LOC_01
       authenticate 1 authentication-service AUTH_SRV username TRUNKNUMBER2
 
 context sip-gateway ASTERISK_00
-  bind location-service SER_LOC_00
 
   interface IF_GW_SIP_TRAIN_00
     transport-protocol udp+tcp 5060
@@ -151,7 +150,6 @@ context sip-gateway ASTERISK_00
   no shutdown
 
 context sip-gateway ASTERISK_01
-  bind location-service SER_LOC_01
 
   interface IF_GW_SIP_TRAIN_01
     transport-protocol udp+tcp 5062

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_ISDN_4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_ISDN_4.txt
@@ -203,7 +203,6 @@ location-service SER_LOC_03
       authenticate 1 authentication-service AUTH_SRV username TRUNKNUMBER4
 
 context sip-gateway ASTERISK_00
-  bind location-service SER_LOC_00
 
   interface IF_GW_SIP_TRAIN_00
     transport-protocol udp+tcp 5060
@@ -213,7 +212,6 @@ context sip-gateway ASTERISK_00
   no shutdown
 
 context sip-gateway ASTERISK_01
-  bind location-service SER_LOC_01
 
   interface IF_GW_SIP_TRAIN_01
     transport-protocol udp+tcp 5062
@@ -223,7 +221,6 @@ context sip-gateway ASTERISK_01
   no shutdown
 
 context sip-gateway ASTERISK_02
-  bind location-service SER_LOC_02
 
   interface IF_GW_SIP_TRAIN_02
     transport-protocol udp+tcp 5064
@@ -233,7 +230,6 @@ context sip-gateway ASTERISK_02
   no shutdown
 
 context sip-gateway ASTERISK_03
-  bind location-service SER_LOC_03
 
   interface IF_GW_SIP_TRAIN_03
     transport-protocol udp+tcp 5066

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_PRI_1.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_PRI_1.txt
@@ -112,7 +112,6 @@ location-service SER_LOC_00
       authenticate 1 authentication-service AUTH_SRV username TRUNKNUMBER1
 
 context sip-gateway ASTERISK_00
-  bind location-service SER_LOC_00
 
   interface IF_GW_SIP_TRAIN_00
     transport-protocol udp+tcp 5060

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_PRI_2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_PRI_2.txt
@@ -142,7 +142,6 @@ location-service SER_LOC_01
       authenticate 1 authentication-service AUTH_SRV username TRUNKNUMBER2
 
 context sip-gateway ASTERISK_00
-  bind location-service SER_LOC_00
 
   interface IF_GW_SIP_TRAIN_00
     transport-protocol udp+tcp 5060
@@ -152,7 +151,6 @@ context sip-gateway ASTERISK_00
   no shutdown
 
 context sip-gateway ASTERISK_01
-  bind location-service SER_LOC_01
 
   interface IF_GW_SIP_TRAIN_01
     transport-protocol udp+tcp 5062

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_PRI_4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/TRI_PRI_4.txt
@@ -203,7 +203,6 @@ location-service SER_LOC_03
       authenticate 1 authentication-service AUTH_SRV username TRUNKNUMBER4
 
 context sip-gateway ASTERISK_00
-  bind location-service SER_LOC_00
 
   interface IF_GW_SIP_TRAIN_00
     transport-protocol udp+tcp 5060
@@ -213,7 +212,6 @@ context sip-gateway ASTERISK_00
   no shutdown
 
 context sip-gateway ASTERISK_01
-  bind location-service SER_LOC_01
 
   interface IF_GW_SIP_TRAIN_01
     transport-protocol udp+tcp 5062
@@ -223,7 +221,6 @@ context sip-gateway ASTERISK_01
   no shutdown
 
 context sip-gateway ASTERISK_02
-  bind location-service SER_LOC_02
 
   interface IF_GW_SIP_TRAIN_02
     transport-protocol udp+tcp 5064
@@ -233,7 +230,6 @@ context sip-gateway ASTERISK_02
   no shutdown
 
 context sip-gateway ASTERISK_03
-  bind location-service SER_LOC_03
 
   interface IF_GW_SIP_TRAIN_03
     transport-protocol udp+tcp 5066


### PR DESCRIPTION
New Trinity firmware 3.17.1 ( or firmware > April 2020) introduces  Security improvements for the SIP Location Service by forcing inbound authentication in most scenarios.

https://www.patton.com/trinity/release_notes.asp?id=125

Authentication is disabled on a  local device.
For other scenarios (Trinity Patton from remote) we need to reimplement the configuration of the template and trunk.