### PR TITLE
Add sleep on push config for Trinity Patton

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/gateway/pushtftp/trinity-tftp
+++ b/root/var/www/html/freepbx/rest/lib/gateway/pushtftp/trinity-tftp
@@ -40,6 +40,7 @@ send "copy tftp://$tftpip/$filename config:tmp-config\r"
 expect "#"
 send "copy config:tmp-config startup-config\r"
 expect "#"
+sleep 5
 send "reload\r"
 expect "#"
 send "yes\r"


### PR DESCRIPTION
From 3.16.0 firmware https://www.patton.com/trinity/release_notes.asp?id=116 the copy command of trinity Patton is now asynchronous, a waiting time is necessary to allow the command to be executed.