### PR TITLE
Use lock on CTI profile POST

### DIFF
--- a/root/var/www/html/freepbx/rest/modules/cti.php
+++ b/root/var/www/html/freepbx/rest/modules/cti.php
@@ -83,12 +83,14 @@ $app->post('/cti/profiles/{id}', function (Request $request, Response $response,
         $sharedLock = '/var/run/nethvoice/contextLock';
         $timeoutSeconds = 5;
 
-        // Check lock file
-        if ( !file_exists(dirname($sharedLock)) || !is_writable(dirname($sharedLock)) || (file_exists($sharedLock) && filemtime($sharedLock) > time()-$timeoutSeconds)) {
+        // Check and create lock file
+        if ( !file_exists(dirname($sharedLock))
+            || !is_writable(dirname($sharedLock))
+            || ( file_exists($sharedLock) && filemtime($sharedLock) > time()-$timeoutSeconds )
+            || !touch($sharedLock))
+        {
             throw new Exception('Can\'t acquire lock');
         }
-
-        $lock = touch($sharedLock);
 
         $res = postCTIProfile($profile,$id);
 


### PR DESCRIPTION
Use lock on on CTI/profile POST to avoid race conditions.
Return 500 if lock can't be acquired
https://github.com/nethesis/dev/issues/5979