### PR TITLE
Escape mysql characters in context description

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/contextMigrationHelper.php
+++ b/root/var/www/html/freepbx/rest/lib/contextMigrationHelper.php
@@ -51,6 +51,7 @@ try {
         // Assign context to extension for each CTI profile
         setCTIUserProfile($user['id'],$user['profile']);
     }
+    system('/var/www/html/freepbx/rest/lib/retrieveHelper.sh > /dev/null &');
 } catch (Exception $e) {
     error_log($e->getMessage());
     exit (1);

--- a/root/var/www/html/freepbx/rest/lib/libCTI.php
+++ b/root/var/www/html/freepbx/rest/lib/libCTI.php
@@ -408,7 +408,7 @@ function setCustomContextPermissions($profile_id){
     }
     if (!$context_exists) {
         // Create customcontext for this profile
-        customcontexts_customcontexts_add($context_name, 'CTI Profile '.$profile['name'],null,null,null,null,null);
+        customcontexts_customcontexts_add($context_name, 'CTI Profile '.addslashes($profile['name']),null,null,null,null,null);
         /* set default permission for context*/
         $context_permissions = array();
         foreach (customcontexts_getincludes($context_name) as $val) {


### PR DESCRIPTION
In https://github.com/nethesis/dev/issues/6032, if context description contains mysql characters that need to be escaped, the FreePBX function that add context breaks and context isn't added