### PR TITLE
Fix congestion tone for Patton

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4112fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4112fxo.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxo.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxs.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxs.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxs_fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4114fxs_fxo.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4116fxs4_fxo2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4116fxs4_fxo2.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4118fxs.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4118fxs.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4118fxs_fxo.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4118fxs_fxo.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4526fxs.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4526fxs.txt
@@ -28,7 +28,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs2_fxo2_isdn2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs2_fxo2_isdn2.txt
@@ -32,7 +32,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_fxo4_isdn4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_fxo4_isdn4.txt
@@ -35,7 +35,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_isdn2.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_isdn2.txt
@@ -32,7 +32,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_isdn4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_isdn4.txt
@@ -35,7 +35,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_isdn8.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4661fxs4_isdn8.txt
@@ -39,7 +39,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4671fxs8_isdn4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4671fxs8_isdn4.txt
@@ -35,7 +35,7 @@ profile call-progress-tone IT_Busytone
 
 profile call-progress-tone IT_Congestion
   play 1 200 425 -12
-  pause 2 200
+  pause 2 250
 
 profile tone-set default
   map call-progress-tone dial-tone IT_Dialtone

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4970.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4970.txt
@@ -17,16 +17,6 @@ profile r2 default
 
 profile ppp default
 
-profile call-progress-tone defaultDialtone
-  play 1 200 425 0
-  pause 2 200
-  play 3 600 425 0
-  pause 4 1000
-
-profile call-progress-tone defaultBusytone
-  play 1 200 425 -7
-  pause 2 200
-
 profile tone-set default
 
 profile voip default

--- a/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4970_4.txt
+++ b/root/var/www/html/freepbx/rest/lib/gateway/templates/Patton/4970_4.txt
@@ -20,16 +20,6 @@ profile r2 default
 
 profile ppp default
 
-profile call-progress-tone defaultDialtone
-  play 1 200 425 0
-  pause 2 200
-  play 3 600 425 0
-  pause 4 1000
-
-profile call-progress-tone defaultBusytone
-  play 1 200 425 -7
-  pause 2 200
-
 profile tone-set default
 
 profile voip default


### PR DESCRIPTION
- Fix congestion tone for analog Patton from 200 to 250 ms.
- Delete tone definition from PRI Patton (digital Patton doesn't need it)