### PR TITLE
wait for tftp operation to be concluded

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/gateway/pushtftp/trinity-tftp
+++ b/root/var/www/html/freepbx/rest/lib/gateway/pushtftp/trinity-tftp
@@ -38,9 +38,9 @@ send "enable\r"
 expect "#"
 send "copy tftp://$tftpip/$filename config:tmp-config\r"
 expect "#"
+sleep 5
 send "copy config:tmp-config startup-config\r"
 expect "#"
-sleep 5
 send "reload\r"
 expect "#"
 send "yes\r"


### PR DESCRIPTION
before copy tmp-config to startup-config is necessary to wait that the tftpcopy is ended (async operation).

https://github.com/nethesis/dev/issues/6077