### PR TITLE
update context form array instead of readin permission from db

### DIFF
--- a/root/var/www/html/freepbx/rest/lib/contextMigrationHelper.php
+++ b/root/var/www/html/freepbx/rest/lib/contextMigrationHelper.php
@@ -28,7 +28,7 @@ try {
     // Create or edit contexts for each CTI profile
     $profiles = getCTIPermissionProfiles(false,false,false);
     foreach ($profiles as $profile) {
-        setCustomContextPermissions($profile['id']);
+        setCustomContextPermissions($profile);
     }
     $users = getAllUsers();
     foreach ($users as $user) {

--- a/root/var/www/html/freepbx/rest/lib/libCTI.php
+++ b/root/var/www/html/freepbx/rest/lib/libCTI.php
@@ -424,6 +424,8 @@ function postCTIProfile($profile, $id=false){
             $id = $dbh->sql($sql,"getOne");
         }
 
+        $profile['id'] = $id;
+
         //set macro_permissions
         foreach (getAllAvailableMacroPermissions() as $macro_permission) {
             if (!$profile['macro_permissions'][$macro_permission['name']]['value']) {
@@ -498,7 +500,7 @@ function postCTIProfile($profile, $id=false){
             }
         }
 
-        setCustomContextPermissions($id);
+        setCustomContextPermissions($profile);
         return $id;
     } catch (Exception $e) {
         error_log($e->getMessage());
@@ -506,10 +508,9 @@ function postCTIProfile($profile, $id=false){
     }
 }
 
-function setCustomContextPermissions($profile_id){
+function setCustomContextPermissions($profile){
     global $context_default_permissions;
     global $context_permission_map;
-    $profile = getCTIPermissionProfiles($profile_id);
     /* Create custom context if needed */
     $contexts = customcontexts_getcontexts();
     $context_exists = False;
@@ -517,7 +518,7 @@ function setCustomContextPermissions($profile_id){
     if ($profile['name'] === 'Hotel') {
         $context_name = 'hotel';
     } else {
-        $context_name = 'cti-profile-'.$profile_id;
+        $context_name = 'cti-profile-'.$profile['id'];
     }
 
     foreach ($contexts as $context) {


### PR DESCRIPTION
Since routes are now read directly from context, they weren't updated when profiles were saved because permissions were read again from db. Now the setCustomContextPermissions is called with the profile array containing all permissions instead of reading permissions again from db using the profile id
https://github.com/nethesis/dev/issues/6191