### PR TITLE
Added `domain` attribute to `/userprovider` API

### DIFF
--- a/modules/configuration.php
+++ b/modules/configuration.php
@@ -33,8 +33,17 @@ function setLegacyMode($value) {
 
 
 $app->get('/configuration/userprovider', function (Request $request, Response $response, $args) {
-	# Dummy user provider response
-	return $response->withJson(json_decode('{"configured":1,"type":"ldap","local":1}'),200);
+    # Get domain
+    $provider_domain = getenv('NETHVOICE_LDAP_BASE');
+
+    # Parse domain
+    $dcs = explode("dc=", $provider_domain);
+    array_shift($dcs);
+    $domain_raw = implode(".", $dcs);
+    $domain = str_replace(',', '', $domain_raw);
+
+    # Dummy user provider response
+    return $response->withJson(json_decode('{ "configured":1, "type":"ldap", "local":1, "domain": "'.$domain.'" }'), 200);
 });
 
 # get enabled mode

--- a/modules/configuration.php
+++ b/modules/configuration.php
@@ -42,7 +42,7 @@ $app->get('/configuration/userprovider', function (Request $request, Response $r
     $domain_raw = implode(".", $dcs);
     $domain = str_replace(',', '', $domain_raw);
 
-    # Dummy user provider response
+    # Return user provider object
     return $response->withJson(json_decode('{ "configured":1, "type":"ldap", "local":1, "domain": "'.$domain.'" }'), 200);
 });
 


### PR DESCRIPTION
In order to generate the user-portal link, we have to add the `domain` attribute to the API dynamically.

Reference: https://github.com/nethesis/ns8-nethvoice/issues/106